### PR TITLE
Exclude actions not allowed to use outside

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -153,12 +153,12 @@ async function findAllActions(
     const content = await getActionFile(client, repo)
     if (content && content.name !== '') {
       core.info(
-        `Found action file in repository: ${repo.name} with filename [${content.name}] download url [${content.downloadUrl}]. Visibility of repo is ${repo.visibility}`
+        `Found action file in repository: [${repo.name}] with filename [${content.name}] download url [${content.downloadUrl}]. Visibility of repo is [${repo.visibility}]`
       )
 
       // Check and exclude the Work in progress actions if its internal
       if (repo.visibility == 'internal') {
-        core.debug(`Get Access settings for repository ${repo.owner}/${repo.name}..............`)
+        core.debug(`Get cccess settings for repository [${repo.owner}/${repo.name}] ..............`)
 
         const { data: accessSettings } = await client.rest.actions.getWorkflowAccessToRepository({
           owner: repo.owner,
@@ -169,7 +169,7 @@ async function findAllActions(
           continue
         }
       } else if (repo.visibility == 'private') {
-        core.info(`${repo.owner}/${repo.name} is private repo.`)
+        core.info(`[${repo.owner}/${repo.name}] is a private repo.`)
         continue
       }
 


### PR DESCRIPTION

1. Action data populates all the action repos that is accessible to the used token
Filter the data based on below conditions
1. If repo visibility is private - Don't add to dataset
2. If internal repo
      - [Get the level of access for workflows outside of the repository](https://docs.github.com/en/rest/actions/permissions#get-the-level-of-access-for-workflows-outside-of-the-repository)
      - If access_level is none - Don't add to the data set