### PR TITLE
Added ratelimit support to prevent issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
   # Enable version updates for actions
   - package-ecosystem: 'github-actions'
     # Look for `package.json` and `lock` files in the `root` directory
-    directory: '.github/workflows/'
+    directory: '/'
     # Check the npm registry for updates every week
     schedule:
       interval: 'monthly'

--- a/dist/main.js
+++ b/dist/main.js
@@ -26741,7 +26741,7 @@ function getActionFile(client, repo) {
     }
     var ratelimit = yield client.rest.rateLimit.get();
     core.info(`Remaining search API calls: ${ratelimit.data.resources.search.remaining}`);
-    if (ratelimit.data.resources.search.remaining < 1) {
+    if (ratelimit.data.resources.search.remaining <= 1) {
       var resetTime = new Date(ratelimit.data.resources.search.reset * 1e3);
       core.info(`Search API reset time: ${resetTime}`);
       var waitTime = resetTime.getTime() - new Date().getTime();

--- a/dist/main.js
+++ b/dist/main.js
@@ -26745,7 +26745,10 @@ function getActionFile(client, repo) {
       var resetTime = new Date(ratelimit.data.resources.search.reset * 1e3);
       core.info(`Search API reset time: ${resetTime}`);
       var waitTime = resetTime.getTime() - new Date().getTime();
-      core.info(`Waiting ${waitTime} milliseconds to prevent the search API rate limit`);
+      core.info(`Waiting ${waitTime / 1e3} seconds to prevent the search API rate limit`);
+      if (waitTime < 0) {
+        waitTime = 1e3;
+      }
       yield new Promise((r) => setTimeout(r, waitTime));
     }
     if (result.name === "") {

--- a/dist/main.js
+++ b/dist/main.js
@@ -26747,7 +26747,9 @@ function getActionFile(client, repo) {
       var waitTime = resetTime.getTime() - new Date().getTime();
       core.info(`Waiting ${waitTime / 1e3} seconds to prevent the search API rate limit`);
       if (waitTime < 0) {
-        waitTime = 1e3;
+        waitTime = 2500;
+      } else {
+        waitTime = waitTime + 1e3;
       }
       yield new Promise((r) => setTimeout(r, waitTime));
     }

--- a/dist/main.js
+++ b/dist/main.js
@@ -26746,6 +26746,7 @@ function getActionFile(client, repo) {
       var searchResultforRepository = yield client.request("GET /search/code", {
         q: searchQuery
       });
+      core.info(`Waiting 2 seconds to prevent the search API rate limit`);
       yield new Promise((r) => setTimeout(r, 2e3));
       if (Object.keys(searchResultforRepository.data.items).length > 0) {
         for (let index = 0; index < Object.keys(searchResultforRepository.data.items).length; index++) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -239,7 +239,11 @@ async function getActionFile(
     core.info(`Search API reset time: ${resetTime}`)
     // wait until the reset time
     var waitTime = resetTime.getTime() - new Date().getTime()
-    core.info(`Waiting ${waitTime} milliseconds to prevent the search API rate limit`)
+    core.info(`Waiting ${waitTime/1000} seconds to prevent the search API rate limit`)
+    if (waitTime < 0) {
+      // if the reset time is in the past, wait 1 second
+      waitTime = 1000
+    }
     await new Promise(r => setTimeout(r, waitTime));
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -233,7 +233,7 @@ async function getActionFile(
   // search API has a strict rate limit, prevent errors
   var ratelimit = await client.rest.rateLimit.get()
   core.info(`Remaining search API calls: ${ratelimit.data.resources.search.remaining}`)
-  if (ratelimit.data.resources.search.remaining < 1) {
+  if (ratelimit.data.resources.search.remaining <= 1) {
       // show the reset time
     var resetTime = new Date(ratelimit.data.resources.search.reset * 1000)
     core.info(`Search API reset time: ${resetTime}`)

--- a/src/main.ts
+++ b/src/main.ts
@@ -239,6 +239,7 @@ async function getActionFile(
     });
 
     // wait 2 seconds after this call, to prevent the search API rate limit
+    core.info(`Waiting 2 seconds to prevent the search API rate limit`)
     await new Promise(r => setTimeout(r, 2000));
 
     if (Object.keys(searchResultforRepository.data.items).length > 0) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -230,6 +230,19 @@ async function getActionFile(
     }
   }
 
+  // search API has a strict rate limit, prevent errors
+  var ratelimit = await client.rest.rateLimit.get()
+  core.info(`Remaining search API calls: ${ratelimit.data.resources.search.remaining}`)
+  if (ratelimit.data.resources.search.remaining < 1) {
+      // show the reset time
+    var resetTime = new Date(ratelimit.data.resources.search.reset * 1000)
+    core.info(`Search API reset time: ${resetTime}`)
+    // wait until the reset time
+    var waitTime = resetTime.getTime() - new Date().getTime()
+    core.info(`Waiting ${waitTime} milliseconds to prevent the search API rate limit`)
+    await new Promise(r => setTimeout(r, waitTime));
+  }
+
   if (result.name === '') {
     core.info(`No actions found at root level in repository: ${repo.name}`)
     core.info(`Checking subdirectories in repository: ${repo.name}`)
@@ -238,19 +251,6 @@ async function getActionFile(
     var searchResultforRepository = await client.request("GET /search/code", {
       q: searchQuery
     });
-
-    // search API has a strict rate limit, prevent errors
-    var ratelimit = await client.rest.rateLimit.get()
-    core.info(`Remaining search API calls: ${ratelimit.data.resources.search.remaining}`)
-    if (ratelimit.data.resources.search.remaining < 1) {
-        // show the reset time
-      var resetTime = new Date(ratelimit.data.resources.search.reset * 1000)
-      core.info(`Search API reset time: ${resetTime}`)
-      // wait until the reset time
-      var waitTime = resetTime.getTime() - new Date().getTime()
-      core.info(`Waiting ${waitTime} milliseconds to prevent the search API rate limit`)
-      await new Promise(r => setTimeout(r, waitTime));
-    }
 
     if (Object.keys(searchResultforRepository.data.items).length > 0) {
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { Octokit } from 'octokit'
 import YAML from 'yaml'
 import GetDateFormatted from './utils'
 import dotenv from 'dotenv'
+import { wait } from './wait'
 
 // always import the config
 dotenv.config()
@@ -241,8 +242,11 @@ async function getActionFile(
     var waitTime = resetTime.getTime() - new Date().getTime()
     core.info(`Waiting ${waitTime/1000} seconds to prevent the search API rate limit`)
     if (waitTime < 0) {
-      // if the reset time is in the past, wait 1 second
-      waitTime = 1000
+      // if the reset time is in the past, wait 2,5 seconds for good measure (Search API rate limit is 30 requests per minute)
+      waitTime = 2500
+    } else {
+      // back off a bit more to be more certain
+      waitTime = waitTime + 1000
     }
     await new Promise(r => setTimeout(r, waitTime));
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -164,6 +164,7 @@ async function findAllActions(
           owner: repo.owner,
           repo: repo.name,
         })
+
         if (accessSettings.access_level == 'none') {
           core.info(`Access to use action [${repo.owner}/${repo.name}] is disabled`)
           continue
@@ -241,6 +242,11 @@ async function getActionFile(
     // wait 2 seconds after this call, to prevent the search API rate limit
     core.info(`Waiting 2 seconds to prevent the search API rate limit`)
     await new Promise(r => setTimeout(r, 2000));
+    var ratelimit = await client.rest.rateLimit.get()
+    core.info(`Remaining search API calls: ${ratelimit.data.resources.search.remaining}`)
+    // show the reset time
+    var resetTime = new Date(ratelimit.data.resources.search.reset * 1000)
+    core.info(`Search API reset time: ${resetTime}`)
 
     if (Object.keys(searchResultforRepository.data.items).length > 0) {
 


### PR DESCRIPTION
Ratelimit for seach is 30 calls a minute, so we need to check the state of the rate limit and back off in case of need.