### PR TITLE
Keep the json structure constant with default values

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -26793,9 +26793,10 @@ function enrichActionFiles(client, actionFiles) {
         const { data: content } = yield client.request({ url: action.downloadUrl });
         try {
           const parsed = import_yaml.default.parse(content);
-          action.name = parsed.name;
-          action.author = parsed.author;
-          action.description = parsed.description;
+          const defaultValue = "undefined";
+          action.name = parsed.name ? parsed.name : defaultValue;
+          action.author = parsed.author ? parsed.author : defaultValue;
+          action.description = parsed.description ? parsed.description : defaultValue;
         } catch (error) {
           console.log(
             `Error parsing action file in repo [${action.repo}] with error:`

--- a/src/main.ts
+++ b/src/main.ts
@@ -304,9 +304,10 @@ async function enrichActionFiles(
       // try to parse the yaml
       try {
         const parsed = YAML.parse(content)
-        action.name = parsed.name
-        action.author = parsed.author
-        action.description = parsed.description
+        const defaultValue = "undefined" // Default value for json fields is not defined
+        action.name = parsed.name ? parsed.name : defaultValue
+        action.author = parsed.author ? parsed.author : defaultValue
+        action.description = parsed.description ? parsed.description : defaultValue
       } catch (error) {
         // this happens in https://github.com/gaurav-nelson/github-action-markdown-link-check/blob/9de9db77de3b29b650d2e2e99f0ee290f435214b/action.yml#L9
         // because of invalid yaml

--- a/src/main.ts
+++ b/src/main.ts
@@ -304,7 +304,7 @@ async function enrichActionFiles(
       // try to parse the yaml
       try {
         const parsed = YAML.parse(content)
-        const defaultValue = "undefined" // Default value for json fields is not defined
+        const defaultValue = "Undefined" // Default value when json field is not defined
         action.name = parsed.name ? parsed.name : defaultValue
         action.author = parsed.author ? parsed.author : defaultValue
         action.description = parsed.description ? parsed.description : defaultValue


### PR DESCRIPTION
What is happening now ?

- JSON data structure is not uniform , when the author / description / the name of action is not defined in the YAML. 
- Filtering on these fields ( example for search functionality ) is hard since the function fails for undefined fields in JSON. 

Solution :

- Keep the JSON structure uniform for all the data received from the action by Injecting a default value if its not defined in the action.yml file.