### PR TITLE
Upgrade PR validation

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -2,6 +2,8 @@ name: Testing the action
 
 on: 
   push:
+  
+  pull_request:
 
   workflow_dispatch:
 
@@ -26,7 +28,7 @@ jobs:
       - uses: ./
         name: Load available actions
         with: 
-          PAT: ${{ secrets.PAT }} 
+          PAT: ${{ secrets.GITHUB_TOKEN }} 
           user: ${{ env.user }}
         id: load-actions 
 
@@ -74,7 +76,7 @@ jobs:
       - uses: ./
         name: Load available actions
         with: 
-          PAT: ${{ secrets.PAT }} 
+          PAT: ${{ secrets.GITHUB_TOKEN }} 
           user: ${{ vars.USER }}
           outputFilename: actions-second-run.json
         id: load-actions-second-run
@@ -123,7 +125,7 @@ jobs:
       - uses: ./
         name: Load available actions
         with: 
-          PAT: ${{ secrets.PAT }}
+          PAT: ${{ secrets.GITHUB_TOKEN }}
           organization: ${{ env.organization }}
         id: load-actions
 
@@ -170,7 +172,7 @@ jobs:
       - uses: ./
         name: Load available actions
         with: 
-          PAT: ${{ secrets.PAT }}
+          PAT: ${{ secrets.GITHUB_TOKEN }}
           organization: ${{ env.organization }}
         id: load-actions
 


### PR DESCRIPTION
Skip using the PAT so this can run on actual PR's from other folks as well, since the PAT value is not available in the pull_request context