### PR TITLE
Potential fix for code scanning alert no. 73: Unused variable, import, function or class

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,6 +1,5 @@
 import {wait} from '../src/wait'
 import {expect, test} from '@jest/globals'
-import {parseYAML} from '../src/utils'
 
 test('throws invalid number', async () => {
   const input = parseInt('foo', 10)


### PR DESCRIPTION
Potential fix for [https://github.com/devops-actions/load-available-actions/security/code-scanning/73](https://github.com/devops-actions/load-available-actions/security/code-scanning/73)

To fix the issue, the unused `parseYAML` import should be removed from the file. This will improve code readability and maintainability without affecting the functionality of the tests. No additional changes are required, as the rest of the code does not depend on `parseYAML`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
